### PR TITLE
Add input test screen

### DIFF
--- a/lib/input_screen.dart
+++ b/lib/input_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class InputScreen extends StatefulWidget {
+  const InputScreen({super.key});
+
+  @override
+  State<InputScreen> createState() => _InputScreenState();
+}
+
+class _InputScreenState extends State<InputScreen> {
+  final TextEditingController _inputController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lorem Ipsum'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: TextField(
+            controller: _inputController,
+            maxLines: null,
+            decoration: const InputDecoration(
+              labelText: 'Lorem Ipsum',
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:demo_app/defects_screen.dart';
 import 'package:demo_app/form_screen.dart';
+import 'package:demo_app/input_screen.dart';
 import 'package:demo_app/issue_1619_repro.dart';
 import 'package:demo_app/issue_1677_repro.dart';
 import 'package:demo_app/nesting_screen.dart';
@@ -106,6 +107,14 @@ class _MyHomePageState extends State<MyHomePage> {
                   );
                 },
                 child: const Text('Form Test'),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const InputScreen()),
+                  );
+                },
+                child: const Text('Input Test'),
               ),
               ElevatedButton(
                 onPressed: () {


### PR DESCRIPTION
Linked https://github.com/mobile-dev-inc/maestro/pull/2027#issuecomment-2337449253

This adds an input screen with a simple edit text in order to test the `inputText` command.

The corresponding e2e test is added here: https://github.com/mobile-dev-inc/maestro/pull/2027/commits/10854ce0996d61fd9199fda593fea44cd50689a3